### PR TITLE
feat: adding github action to release chart #10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Releases
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**'
+      - 'charts/**'
+      - '!**.md'
+
+jobs:
+
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.changed.outputs.result }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+# 
+#      - id: changed
+#        name: Changed
+#        run: |
+#          files_changed="$(git show --pretty="" --name-only)"
+#          echo "$files_changed"
+#          num_version_bumps="$(echo "$files_changed" | grep Chart.yaml | xargs git show | grep -c "+version" || true)"
+#          if [[ "$num_version_bumps" -eq "1" ]]; then
+#            echo "result=ok" >> $GITHUB_OUTPUT
+#          else
+#            echo "result=skip"
+#            echo "::warning::Version not changed, skipping release job..."
+#          fi
+
+      - name: Tests
+#        if: ${{ steps.changed.outputs.result == 'ok' }}
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm plugin install https://github.com/helm-unittest/helm-unittest
+          for FILE in charts/*; do 
+            helm dependency update $FILE
+            helm unittest $FILE
+          done
+
+  release:
+    needs: validate
+    if: ${{ needs.validate.outputs.result == 'ok' }}
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Add repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm plugin install https://github.com/helm-unittest/helm-unittest
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "cryptpad-helm-{{ .Version }}"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is initial version of [Cryptpad](https://docs.cryptpad.org/en/index.html) c
 ## Usage
 
 ```bash
-helm repo add cryptpad-github https://git.xwikisas.com/api/v4/projects/439/packages/helm/main
+helm repo add cryptpad-github https://cryptpad.github.io/helm
 helm install cryptpad cryptpad-github/cryptpad 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CryptPad Helm Chart
 
-This is initial version of Cryptpad chart helm [Helm Chart](https://helm.sh/) for ease deployment on Kubernetes. 
+This is initial version of [Cryptpad](https://docs.cryptpad.org/en/index.html) chart helm [Helm Chart](https://helm.sh/) for ease deployment on Kubernetes. 
 
 ## Requirements
 
@@ -9,22 +9,11 @@ This is initial version of Cryptpad chart helm [Helm Chart](https://helm.sh/) fo
 ## Usage
 
 ```bash
-helm repo add cryptpad-xwikisas https://git.xwikisas.com/api/v4/projects/439/packages/helm/main
-helm install cryptpad cryptpad-xwikisas/cryptpad 
+helm repo add cryptpad-github https://git.xwikisas.com/api/v4/projects/439/packages/helm/main
+helm install cryptpad cryptpad-github/cryptpad 
 ```
 
-## TODO list
-
-* [Testing] Provide all configs.js (ie storage, adminKeys, other custom configs) to be made using helm/yaml values. 
-* [Testing] Create Storage options and/or kind (Deployment/StatefulSet)
-* [Testing] Custom configs/mappings (customize) and customs configs apps.  
-* Provide example/custom files mapping for customize directory. 
-* Continue to use image from (promasu/cryptpad) ? 
-* Review checkup since some returns seams to be ok but are failing on checking
-* Instructions to setup (if necessary) custom dh parameteres https://kubernetes.github.io/ingress-nginx/examples/customization/ssl-dh-param/
-* Create unit tests for important defaults/settings
-* Prepare some integrated tests to be used on CI/CD
-* Review project and final repository/license/instructions 
+Check [values.yaml](charts/cryptpad/values.yaml) for custom values/settings. 
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CryptPad Helm Chart
 
-This is initial version of [Cryptpad](https://docs.cryptpad.org/en/index.html) chart helm [Helm Chart](https://helm.sh/) for ease deployment on Kubernetes. 
+This is the [CryptPad](https://cryptpad.org) [Helm Chart](https://helm.sh/) for easy deployment on Kubernetes. 
 
 ## Requirements
 

--- a/charts/cryptpad/Chart.yaml
+++ b/charts/cryptpad/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cryptpad/tests/__snapshot__/serviceaccount_test.yaml.snap
+++ b/charts/cryptpad/tests/__snapshot__/serviceaccount_test.yaml.snap
@@ -4,5 +4,5 @@ Assert the service match the snapshot:
       app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: cryptpad
-      helm.sh/chart: cryptpad-0.0.3
+      helm.sh/chart: cryptpad-0.0.4
     name: RELEASE-NAME-cryptpad


### PR DESCRIPTION
Action to release chart. Before merge, we need to turn the repository public and enable GH pages. 