### PR TITLE
charts/cryptpad/values.yaml: increase example values for resource limits and requests

### DIFF
--- a/charts/cryptpad/values.yaml
+++ b/charts/cryptpad/values.yaml
@@ -187,10 +187,10 @@ resources: {}
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
-  #   memory: 128Mi
+  #   memory: 1024Mi
   # requests:
   #   cpu: 100m
-  #   memory: 128Mi
+  #   memory: 1024Mi
 
 autoscaling:
   # -- Enable the Autoscaling


### PR DESCRIPTION
increase example values for resource limits and requests, as the pod won't start with anything lower than 1024Mi

fix #15