### PR TITLE
fix PVC statement indentation

### DIFF
--- a/charts/cryptpad/templates/cryptpad.yaml
+++ b/charts/cryptpad/templates/cryptpad.yaml
@@ -47,8 +47,8 @@ spec:
             - name: cryptpad-data
               mountPath: /cryptpad/data
               {{- if and .Values.persistence .Values.persistence.cryptpad.data.existingClaim }}
-                persistentVolumeClaim:
-                  claimName: {{ tpl .Values.persistence.cryptpad.data.existingClaim $ }}
+              persistentVolumeClaim:
+                claimName: {{ tpl .Values.persistence.cryptpad.data.existingClaim $ }}
               {{- end }}
           args:
             - |
@@ -137,8 +137,8 @@ spec:
             - name: cryptpad-{{ $dir }}
               mountPath: /cryptpad/{{ $dir }}
               {{- if $dirvalues.existingClaim }}
-                persistentVolumeClaim:
-                  claimName: {{ tpl $dirvalues.existingClaim $ }}
+              persistentVolumeClaim:
+                claimName: {{ tpl $dirvalues.existingClaim $ }}
               {{- end }}
           {{- end }}
           {{- else if not .Values.workloadStateful }}

--- a/charts/cryptpad/tests/cryptpad_test.yaml
+++ b/charts/cryptpad/tests/cryptpad_test.yaml
@@ -1,7 +1,7 @@
 suite: test cryptpad
 templates:
-  - templates/cryptpad.yaml
-  - templates/configmap.yaml
+  - configmap.yaml
+  - cryptpad.yaml
 tests:
   - it: should have the good values
     set:
@@ -15,7 +15,7 @@ tests:
     asserts:
       - isKind:
           of: StatefulSet
-        template: templates/cryptpad.yaml
+        template: cryptpad.yaml
 # Prevent requirement of always change snapshots when other improvements/changes are made. 
 #      - matchSnapshot:
 #          path: spec
@@ -26,9 +26,55 @@ tests:
     asserts:
       - isKind:
           of: Deployment
-        template: templates/cryptpad.yaml
-# Prevent requirement of always change snapshots when other improvements/changes are made. 
-# Or check to ignore checksum from configmap from annotations 
-#      - matchSnapshot:
-#          path: spec
-#        template: templates/cryptpad.yaml
+        template: cryptpad.yaml
+  - it: should be able to use existing PV claims
+    set:
+      workloadStateful: false
+      persistence:
+        enabled: true
+        cryptpad:
+          data:
+            existingClaim: "test-pv"
+            storageClass: "test-drive"
+            accessModes:
+              - ReadWriteOnce
+            size: "100Mi"
+          datastore:
+            existingClaim: "test-pv"
+            storageClass: "test-drive"
+            size: "100Mi"
+            accessModes:
+              - ReadWriteOnce
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-cryptpad
+        template: cryptpad.yaml
+      - equal:
+          path: spec.template.spec.initContainers[0].volumeMounts[0].name
+          value: cryptpad-data
+        template: cryptpad.yaml
+      - equal:
+          path: spec.template.spec.initContainers[0].volumeMounts[0].persistentVolumeClaim.claimName
+          value: test-pv
+        template: cryptpad.yaml
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: cryptpad
+        template: cryptpad.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /cryptpad/data
+            name: cryptpad-data
+            persistentVolumeClaim:
+              claimName: test-pv
+        template: cryptpad.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /cryptpad/datastore
+            name: cryptpad-datastore
+            persistentVolumeClaim:
+              claimName: test-pv
+        template: cryptpad.yaml


### PR DESCRIPTION
Hello! First of all, I would like to thank you for a solid work on the helm chart documentation, I was able to find my way around very quickly. However, there seems to be a small issue with how the `cryptpad.yaml` template sets up volume mounts given that one needs to use an existing PVC. In my setup (a Raspberry Pi k3s cluster with an external SSD as its main storage), I needed to use an existing PVC but all my attempts consistently failed with

`Error: yaml: line 38: mapping values are not allowed in this context`

I think these changes are enough to solve the problem.

By the way, do you continuously run the helm test suites somewhere?