### PR TITLE
fix(cryptad): Add resources to initContainer aswell

### DIFF
--- a/charts/cryptpad/templates/cryptpad.yaml
+++ b/charts/cryptpad/templates/cryptpad.yaml
@@ -61,6 +61,8 @@ spec:
               else
                 echo "$VALUE" >> "$FILE"
               fi
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
Some strict kubernetes cluster requires resources to set for any type, so this PR adds the resources for the initContainer aswell.