### PR TITLE
fix: correct chart signing certificate location

### DIFF
--- a/charts/cryptpad/README.md.gotmpl
+++ b/charts/cryptpad/README.md.gotmpl
@@ -24,7 +24,7 @@ Example of how verify signature of helm:
 
 ```bash
   # Download and convert key from ASCII armor format to binary. 
-  curl https://extensions.xwiki.org/xwiki/bin/download/Extension/XWikiHelm/WebHome/helm-charts.asc | gpg --dearmor > helm-charts.gpg 
+  curl https://xwiki-contrib.github.io/xwiki-helm/helm-charts.asc | gpg --dearmor > helm-charts.gpg 
   # Verify thatthe signed chart: 
   helm fetch --verify cryptpad-github/{{ template "chart.name" . }} --version {{ template "chart.version" . }} --keyring helm-charts.gpg 
 ```


### PR DESCRIPTION
This PR corrects the location of the helm chart signing certificate. The old location is invalid; the new location's certificate passes the `--verify` check just below the modified line :) 