### PR TITLE
Fixes and features for restricted environment

### DIFF
--- a/charts/cryptpad/Chart.lock
+++ b/charts/cryptpad/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.40.0
-digest: sha256:af8359af8251da7f04304b76fd4ca78ecbbb3b5ccd3c4c6fec5021afef95e894
-generated: "2026-05-29T08:49:08.5066264+02:00"

--- a/charts/cryptpad/Chart.yaml
+++ b/charts/cryptpad/Chart.yaml
@@ -33,7 +33,3 @@ maintainers:
     email: guilherme.sautner@xwiki.com
   - name: Arsène Fougerouse
     email: arsene.fougerouse@xwiki.com
-dependencies:
-  - name: common
-    repository: oci://registry-1.docker.io/bitnamicharts
-    version: 2.x.x

--- a/charts/cryptpad/templates/NOTES.txt
+++ b/charts/cryptpad/templates/NOTES.txt
@@ -1,10 +1,14 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.mainDomain }}
+  {{- if .Values.sandboxDomain }}
+  http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.sandboxDomain }} (sandbox)
   {{- end }}
-{{- end }}
+{{- else if .Values.httpRoute.enabled }}
+  https://{{ .Values.mainDomain }}
+  {{- if .Values.sandboxDomain }}
+  https://{{ .Values.sandboxDomain }} (sandbox)
+  {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cryptpad-helm.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/cryptpad/templates/_helpers.tpl
+++ b/charts/cryptpad/templates/_helpers.tpl
@@ -62,11 +62,11 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Define main domain. Or use first ingress host defined as main domain.
+Define main domain (httpUnsafeOrigin / CPAD_MAIN_DOMAIN).
 */}}
 {{- define "cryptpad-helm.mainDomain" -}}
-{{- if .Values.ingress.enabled }}
-https://{{ (index .Values.ingress.hosts 0).host }}
+{{- if .Values.mainDomain }}
+https://{{ .Values.mainDomain }}
 {{- else if .Values.config.httpUnsafeOrigin }}
 {{- .Values.config.httpUnsafeOrigin }}
 {{- else }}
@@ -75,22 +75,14 @@ http://localhost:3000
 {{- end }}
 
 {{/*
-Define sandbox domain (httpSafeOrigin). Uses ingress.sandboxHost or httpRoute.sandboxHost when set,
-falling back to the main host only as a last resort (which is insecure for CryptPad).
+Define sandbox domain (httpSafeOrigin / CPAD_SANDBOX_DOMAIN).
+Falls back to mainDomain when sandboxDomain is unset (insecure — same origin).
 */}}
 {{- define "cryptpad-helm.sandboxDomain" -}}
-{{- if .Values.ingress.enabled }}
-{{- if .Values.ingress.sandboxHost }}
-https://{{ .Values.ingress.sandboxHost }}
-{{- else }}
-https://{{ (index .Values.ingress.hosts 0).host }}
-{{- end }}
-{{- else if .Values.httpRoute.enabled }}
-{{- if .Values.httpRoute.sandboxHost }}
-https://{{ .Values.httpRoute.sandboxHost }}
-{{- else }}
-https://{{ index .Values.httpRoute.hosts 0 }}
-{{- end }}
+{{- if .Values.sandboxDomain }}
+https://{{ .Values.sandboxDomain }}
+{{- else if .Values.mainDomain }}
+https://{{ .Values.mainDomain }}
 {{- else if .Values.config.httpSafeOrigin }}
 {{- .Values.config.httpSafeOrigin }}
 {{- else }}

--- a/charts/cryptpad/templates/_helpers.tpl
+++ b/charts/cryptpad/templates/_helpers.tpl
@@ -75,11 +75,22 @@ http://localhost:3000
 {{- end }}
 
 {{/*
-Define sandbox subdomain. Or use first ingress host defined as main domain.
+Define sandbox domain (httpSafeOrigin). Uses ingress.sandboxHost or httpRoute.sandboxHost when set,
+falling back to the main host only as a last resort (which is insecure for CryptPad).
 */}}
 {{- define "cryptpad-helm.sandboxDomain" -}}
 {{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.sandboxHost }}
+https://{{ .Values.ingress.sandboxHost }}
+{{- else }}
 https://{{ (index .Values.ingress.hosts 0).host }}
+{{- end }}
+{{- else if .Values.httpRoute.enabled }}
+{{- if .Values.httpRoute.sandboxHost }}
+https://{{ .Values.httpRoute.sandboxHost }}
+{{- else }}
+https://{{ index .Values.httpRoute.hosts 0 }}
+{{- end }}
 {{- else if .Values.config.httpSafeOrigin }}
 {{- .Values.config.httpSafeOrigin }}
 {{- else }}

--- a/charts/cryptpad/templates/configmap.yaml
+++ b/charts/cryptpad/templates/configmap.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/cryptpad/templates/configmap.yaml
+++ b/charts/cryptpad/templates/configmap.yaml
@@ -10,31 +10,8 @@ data:
     /* globals module */
 
     module.exports = {
-          {{- if .Values.ingress.enabled}}  
-            httpUnsafeOrigin: 'https://{{ (index .Values.ingress.hosts 0).host }}',
-          {{- else if .Values.config.httpUnsafeOrigin }}
-            httpUnsafeOrigin: {{ .Values.config.httpUnsafeOrigin | quote }}, 
-          {{- else }}
-            httpUnsafeOrigin: 'http://localhost:3000',
-          {{- end}}
-       
-          {{- if .Values.ingress.enabled }}
-            {{- if .Values.ingress.sandboxHost }}
-            httpSafeOrigin: 'https://{{ .Values.ingress.sandboxHost }}',
-            {{- else }}
-            httpSafeOrigin: 'https://{{ (index .Values.ingress.hosts 0).host }}',
-            {{- end }}
-          {{- else if .Values.httpRoute.enabled }}
-            {{- if .Values.httpRoute.sandboxHost }}
-            httpSafeOrigin: 'https://{{ .Values.httpRoute.sandboxHost }}',
-            {{- else }}
-            httpSafeOrigin: 'https://{{ index .Values.httpRoute.hosts 0 }}',
-            {{- end }}
-          {{- else if .Values.config.httpSafeOrigin }}
-            httpSafeOrigin: {{ .Values.config.httpSafeOrigin | quote }},
-          {{- else }}
-            httpSafeOrigin: 'http://localhost:3000',
-          {{- end}}
+          httpUnsafeOrigin: '{{ include "cryptpad-helm.mainDomain" . | trim }}',
+          httpSafeOrigin: '{{ include "cryptpad-helm.sandboxDomain" . | trim }}',
 
           {{- if .Values.config.adminKeys }}
             adminKeys: [

--- a/charts/cryptpad/templates/configmap.yaml
+++ b/charts/cryptpad/templates/configmap.yaml
@@ -42,12 +42,14 @@ data:
           {{- end}}
 
           {{- range $key, $value := .Values.config }}
-            {{- if and (or (ne $key "httpUnsafeOrigin") (ne $key "httpSafeOrigin")) (ne $key "adminKeys")  (ne $key "maxUploadSize")}}
-            {{ $key }}: {{ $value | quote }},
+            {{- if and (ne $key "httpUnsafeOrigin") (ne $key "httpSafeOrigin") (ne $key "adminKeys") (ne $key "maxUploadSize") }}
+              {{- if or (kindIs "bool" $value) (kindIs "float64" $value) (kindIs "int64" $value) }}
+              {{ $key }}: {{ $value }},
+              {{- else }}
+              {{ $key }}: {{ $value | quote }},
+              {{- end }}
             {{- end }}
           {{- end }}
-
-
         };
   application_config.js: |
     /*

--- a/charts/cryptpad/templates/configmap.yaml
+++ b/charts/cryptpad/templates/configmap.yaml
@@ -55,6 +55,8 @@ data:
             {{- if and (ne $key "httpUnsafeOrigin") (ne $key "httpSafeOrigin") (ne $key "adminKeys") (ne $key "maxUploadSize") }}
               {{- if or (kindIs "bool" $value) (kindIs "float64" $value) (kindIs "int64" $value) }}
               {{ $key }}: {{ $value }},
+              {{- else if or (kindIs "slice" $value) (kindIs "map" $value) }}
+              {{ $key }}: {{ $value | toJson }},
               {{- else }}
               {{ $key }}: {{ $value | quote }},
               {{- end }}

--- a/charts/cryptpad/templates/configmap.yaml
+++ b/charts/cryptpad/templates/configmap.yaml
@@ -19,9 +19,19 @@ data:
           {{- end}}
        
           {{- if .Values.ingress.enabled }}
+            {{- if .Values.ingress.sandboxHost }}
+            httpSafeOrigin: 'https://{{ .Values.ingress.sandboxHost }}',
+            {{- else }}
             httpSafeOrigin: 'https://{{ (index .Values.ingress.hosts 0).host }}',
-          {{- else if .Values.config.httpSafeOrigin }}  
-            httpSafeOrigin: {{ .Values.config.httpSafeOrigin | quote }}, 
+            {{- end }}
+          {{- else if .Values.httpRoute.enabled }}
+            {{- if .Values.httpRoute.sandboxHost }}
+            httpSafeOrigin: 'https://{{ .Values.httpRoute.sandboxHost }}',
+            {{- else }}
+            httpSafeOrigin: 'https://{{ index .Values.httpRoute.hosts 0 }}',
+            {{- end }}
+          {{- else if .Values.config.httpSafeOrigin }}
+            httpSafeOrigin: {{ .Values.config.httpSafeOrigin | quote }},
           {{- else }}
             httpSafeOrigin: 'http://localhost:3000',
           {{- end}}

--- a/charts/cryptpad/templates/cryptpad.yaml
+++ b/charts/cryptpad/templates/cryptpad.yaml
@@ -132,7 +132,7 @@ spec:
           readinessProbe:
           {{- if .Values.probes.readiness.httpGet.enabled }}
             httpGet:
-              path: {{ .Values.probes.liveness.httpGet.path }}
+              path: {{ .Values.probes.readiness.httpGet.path }}
               port: {{ .Values.service.containerPort }}
           {{- else }}
             tcpSocket:

--- a/charts/cryptpad/templates/cryptpad.yaml
+++ b/charts/cryptpad/templates/cryptpad.yaml
@@ -147,16 +147,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-          {{- if .Values.persistence.enabled }}
           {{- range $dir, $dirvalues := .Values.persistence.cryptpad }}
             - name: cryptpad-{{ $dir | replace "/" "-" }}
               mountPath: /cryptpad/{{ $dir }}
-          {{- end }}
-          {{- else if not .Values.workloadStateful }}
-          {{- range $dir, $dirvalues := .Values.persistence.cryptpad }}
-            - name: cryptpad-{{ $dir | replace "/" "-" }}
-              mountPath: /cryptpad/{{ $dir }}
-          {{- end }}
           {{- end }}
             - name: configmaps
               mountPath: {{ .Values.cpadConfig }}

--- a/charts/cryptpad/templates/cryptpad.yaml
+++ b/charts/cryptpad/templates/cryptpad.yaml
@@ -50,6 +50,8 @@ spec:
           volumeMounts:
             - name: cryptpad-data
               mountPath: /cryptpad/data
+            - mountPath: /tmp
+              name: tmp
           args:
             - |
               FILE=/cryptpad/data/decrees/decree.ndjson
@@ -164,6 +166,8 @@ spec:
             - name: configmaps
               mountPath: /cryptpad/customize/application_config.js
               subPath: application_config.js
+            - mountPath: /tmp
+              name: tmp
             {{- with .Values.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -183,6 +187,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: configmaps
           configMap:
             name: {{ include "cryptpad-helm.fullname" . }}

--- a/charts/cryptpad/templates/cryptpad.yaml
+++ b/charts/cryptpad/templates/cryptpad.yaml
@@ -148,8 +148,15 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
           {{- range $dir, $dirvalues := .Values.persistence.cryptpad }}
+            {{- $mountPath := printf "/cryptpad/%s" $dir }}
+            {{- $skip := false }}
+            {{- range $.Values.extraVolumeMounts }}
+              {{- if eq .mountPath $mountPath }}{{- $skip = true }}{{- end }}
+            {{- end }}
+            {{- if not $skip }}
             - name: cryptpad-{{ $dir | replace "/" "-" }}
-              mountPath: /cryptpad/{{ $dir }}
+              mountPath: {{ $mountPath }}
+            {{- end }}
           {{- end }}
             - name: configmaps
               mountPath: {{ .Values.cpadConfig }}
@@ -232,7 +239,14 @@ spec:
     {{- end }}
   {{- else }}
     {{- range $dir, $dirvalues := .Values.persistence.cryptpad }}
-        - name: cryptpad-{{ $dir | replace "/" "-" }}
+      {{- $volName := printf "cryptpad-%s" ($dir | replace "/" "-") }}
+      {{- $skip := false }}
+      {{- range $.Values.extraVolumes }}
+        {{- if eq .name $volName }}{{- $skip = true }}{{- end }}
+      {{- end }}
+      {{- if not $skip }}
+        - name: {{ $volName }}
           emptyDir: {}
-  {{- end }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/cryptpad/templates/cryptpad.yaml
+++ b/charts/cryptpad/templates/cryptpad.yaml
@@ -1,8 +1,8 @@
+---
+apiVersion: apps/v1
 {{- if .Values.workloadStateful }}
-apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
 {{- else }}
-apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 {{- end }}
 metadata:

--- a/charts/cryptpad/templates/hpa.yaml
+++ b/charts/cryptpad/templates/hpa.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.autoscaling.enabled }}
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "cryptpad-helm.fullname" . }}
@@ -23,12 +23,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/cryptpad/templates/hpa.yaml
+++ b/charts/cryptpad/templates/hpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
+---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -8,10 +9,10 @@ metadata:
 spec:
   scaleTargetRef:
     {{- if .Values.workloadStateful }}
-    apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+    apiVersion: apps/v1
     kind: StatefulSet
     {{- else }}
-    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+    apiVersion: apps/v1
     kind: Deployment
     {{- end }}
     name: {{ include "cryptpad-helm.fullname" . }}

--- a/charts/cryptpad/templates/httpRoute.yaml
+++ b/charts/cryptpad/templates/httpRoute.yaml
@@ -22,9 +22,9 @@ spec:
   {{- . | toYaml | nindent 2 }}
   {{- end }}
   hostnames:
-  {{- toYaml .Values.httpRoute.hosts | nindent 2 }}
-  {{- if .Values.httpRoute.sandboxHost }}
-  - {{ .Values.httpRoute.sandboxHost | quote }}
+  - {{ .Values.mainDomain | quote }}
+  {{- if .Values.sandboxDomain }}
+  - {{ .Values.sandboxDomain | quote }}
   {{- end }}
   rules:
   - matches:

--- a/charts/cryptpad/templates/httpRoute.yaml
+++ b/charts/cryptpad/templates/httpRoute.yaml
@@ -21,9 +21,10 @@ spec:
   parentRefs:
   {{- . | toYaml | nindent 2 }}
   {{- end }}
-  {{- with .Values.httpRoute.hosts }}
   hostnames:
-  {{- toYaml . | nindent 2 }}
+  {{- toYaml .Values.httpRoute.hosts | nindent 2 }}
+  {{- if .Values.httpRoute.sandboxHost }}
+  - {{ .Values.httpRoute.sandboxHost | quote }}
   {{- end }}
   rules:
   - matches:

--- a/charts/cryptpad/templates/httpRoute.yaml
+++ b/charts/cryptpad/templates/httpRoute.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "cryptpad-helm.fullname" . -}}
+{{- $svcPort := .Values.service.externalPort -}}
+{{- $svcWsPort := .Values.service.websocket.externalPort -}}
+{{- if not .Values.httpRoute.parentRefs }}
+    {{- fail "A valid .Values.httpRoute.parentRefs entry is required when httpRoute.enabled is true" }}
+{{- end }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "cryptpad-helm.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hosts }}
+  hostnames:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  rules:
+  - matches:
+    - path:
+        value: /
+        type: PathPrefix
+    backendRefs:
+    - group: ''
+      kind: Service 
+      name: {{ $fullName }}
+      port: {{ $svcPort }}
+    {{- with .Values.httpRoute.timeouts }}
+    timeouts:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  - matches:
+    - path:
+        value: /cryptpad_websocket
+        type: PathPrefix
+    backendRefs:
+    - group: ''
+      kind: Service 
+      name: {{ $fullName }}
+      port: {{ $svcWsPort }}
+    {{- with .Values.httpRoute.timeouts }}
+    timeouts:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/cryptpad/templates/ingress.yaml
+++ b/charts/cryptpad/templates/ingress.yaml
@@ -21,15 +21,21 @@ spec:
   tls:
     {{- range .Values.ingress.tls }}
     - hosts:
+        {{- if .hosts }}
         {{- range .hosts }}
         - {{ . | quote }}
+        {{- end }}
+        {{- else }}
+        - {{ $.Values.mainDomain | quote }}
+        {{- if $.Values.sandboxDomain }}
+        - {{ $.Values.sandboxDomain | quote }}
+        {{- end }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .Values.mainDomain | quote }}
       http:
         paths:
           - path: /
@@ -46,9 +52,8 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcWsPort }}
-    {{- end }}
-    {{- if .Values.ingress.sandboxHost }}
-    - host: {{ .Values.ingress.sandboxHost | quote }}
+    {{- if .Values.sandboxDomain }}
+    - host: {{ .Values.sandboxDomain | quote }}
       http:
         paths:
           - path: /

--- a/charts/cryptpad/templates/ingress.yaml
+++ b/charts/cryptpad/templates/ingress.yaml
@@ -47,4 +47,23 @@ spec:
                 port:
                   number: {{ $svcWsPort }}
     {{- end }}
+    {{- if .Values.ingress.sandboxHost }}
+    - host: {{ .Values.ingress.sandboxHost | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          - path: /cryptpad_websocket
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcWsPort }}
+    {{- end }}
 {{- end }}

--- a/charts/cryptpad/templates/ingress.yaml
+++ b/charts/cryptpad/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "cryptpad-helm.fullname" . -}}
 {{- $svcPort := .Values.service.externalPort -}}
 {{- $svcWsPort := .Values.service.websocket.externalPort -}}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/cryptpad/templates/pvc.yaml
+++ b/charts/cryptpad/templates/pvc.yaml
@@ -7,11 +7,11 @@ metadata:
   name: cryptpad-{{ $dir | replace "/" "-" }}
   {{- with $dirvalues.annotations }}
   annotations:
-    {{- toYaml . | nindent 10 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with $dirvalues.labels }}
   labels:
-    {{- toYaml . | nindent 10 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   accessModes:
@@ -23,14 +23,14 @@ spec:
   {{- end }}
   {{- with $dirvalues.dataSource }}
   dataSource: 
-    {{- toYaml . | nindent 10 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   resources:
     requests:
       storage: {{ $dirvalues.size | quote }}
   {{- with $dirvalues.selector }}
   selector: 
-    {{- toYaml . | nindent 10 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/cryptpad/templates/service.yaml
+++ b/charts/cryptpad/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/cryptpad/templates/serviceaccount.yaml
+++ b/charts/cryptpad/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/cryptpad/values.yaml
+++ b/charts/cryptpad/values.yaml
@@ -5,6 +5,15 @@
 # -- Number of replicas
 replicaCount: 1
 
+# -- Primary hostname for CryptPad (no scheme). Used for httpUnsafeOrigin, CPAD_MAIN_DOMAIN,
+# and ingress/httpRoute host rules. Example: cryptpad.example.org
+mainDomain: ""
+
+# -- Sandbox hostname for CryptPad security isolation (no scheme). Used for httpSafeOrigin and
+# CPAD_SANDBOX_DOMAIN. Must be a *different* domain or subdomain from mainDomain.
+# If empty, mainDomain is reused (insecure). Example: sandbox.cryptpad.example.org
+sandboxDomain: ""
+
 # -- Enable to choose witch kind of workload will be used: (true) StatefulSet or (false) for Deployment
 workloadStateful: true
 
@@ -196,16 +205,9 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    # if the ingress is enabled, this hostname will be used for httpUnsafeOrigin
-    - host: localhost
-  # -- Separate origin for the CryptPad sandbox iframe (httpSafeOrigin).
-  # CryptPad requires this to be a *different* domain or subdomain from the main host
-  # for security isolation. If left empty, the main host is reused (insecure).
-  # Example: sandbox.cryptpad.example.org
-  sandboxHost: ""
   tls: []
   #  - secretName: secret-tls
+  #    hosts: []  # auto-populated from mainDomain/sandboxDomain when empty
 
 httpRoute:
   enabled: false
@@ -216,11 +218,6 @@ httpRoute:
   #- name: default-gateway
   #  namespace: infrastructure-envoy-gateway-default
   #  sectionName: default
-  hosts:
-  - localhost
-  # -- Separate origin for the CryptPad sandbox iframe (httpSafeOrigin).
-  # Must be a different domain or subdomain from the main host. If empty, main host is reused.
-  sandboxHost: ""
   timeouts: {}
     # backendRequest: 120s
 

--- a/charts/cryptpad/values.yaml
+++ b/charts/cryptpad/values.yaml
@@ -202,6 +202,21 @@ ingress:
   tls: []
   #  - secretName: secret-tls
 
+httpRoute:
+  enabled: false
+  annotations: {}
+  labels: {}
+  parentRefs: []
+  # -- requires cluster enabled default gateway (here envoy as example)
+  #- name: default-gateway
+  #  namespace: infrastructure-envoy-gateway-default
+  #  sectionName: default
+  hosts:
+  - localhost
+  timeouts: {}
+    # backendRequest: 120s
+
+
 # -- Specify default resources.
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little

--- a/charts/cryptpad/values.yaml
+++ b/charts/cryptpad/values.yaml
@@ -197,8 +197,13 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    # if the ingress is enabled, this hostname will be used for httpUnsafeOrigin and httpSafeOrigin
+    # if the ingress is enabled, this hostname will be used for httpUnsafeOrigin
     - host: localhost
+  # -- Separate origin for the CryptPad sandbox iframe (httpSafeOrigin).
+  # CryptPad requires this to be a *different* domain or subdomain from the main host
+  # for security isolation. If left empty, the main host is reused (insecure).
+  # Example: sandbox.cryptpad.example.org
+  sandboxHost: ""
   tls: []
   #  - secretName: secret-tls
 
@@ -213,6 +218,9 @@ httpRoute:
   #  sectionName: default
   hosts:
   - localhost
+  # -- Separate origin for the CryptPad sandbox iframe (httpSafeOrigin).
+  # Must be a different domain or subdomain from the main host. If empty, main host is reused.
+  sandboxHost: ""
   timeouts: {}
     # backendRequest: 120s
 

--- a/charts/cryptpad/values.yaml
+++ b/charts/cryptpad/values.yaml
@@ -212,7 +212,6 @@ ingress:
 httpRoute:
   enabled: false
   annotations: {}
-  labels: {}
   parentRefs: []
   # -- requires cluster enabled default gateway (here envoy as example)
   #- name: default-gateway

--- a/charts/cryptpad/values.yaml
+++ b/charts/cryptpad/values.yaml
@@ -242,7 +242,8 @@ autoscaling:
   # -- Minimal numbers of replicas
   minReplicas: 1
   # -- Maximum numbers of replicas
-  maxReplicas: 100
+  # TODO: does cryptpad support HA?
+  maxReplicas: 1
   # -- Percentage of the targeted CPU Utilization
   targetCPUUtilizationPercentage: 80
   # -- Percentage of the targeted Memory Utilization


### PR DESCRIPTION
- add httpRoute ressources (alternative to ingress) where a GatewayAPI configuration already exists (like envoy)
- volume/mount fixes, where when someone wants to use customized PVCs, volume creation clashed with extras
- minor cosmetic fixes
- removed bitnami dependency, as this is not really needed
- use global host variables to configure ingress and httpRoute
