### PR TITLE
Add support for deployment.annotations in Cryptpad chart

### DIFF
--- a/charts/cryptpad/Chart.lock
+++ b/charts/cryptpad/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.39.0
-digest: sha256:3eb3792ee943930941c29d63cd9c9ec07b7ce0da04b23e6b6eb4378a7ea9c0a0
-generated: "2026-05-15T15:55:14.210952212+02:00"
+  version: 2.40.0
+digest: sha256:af8359af8251da7f04304b76fd4ca78ecbbb3b5ccd3c4c6fec5021afef95e894
+generated: "2026-05-29T08:49:08.5066264+02:00"

--- a/charts/cryptpad/templates/cryptpad.yaml
+++ b/charts/cryptpad/templates/cryptpad.yaml
@@ -9,6 +9,10 @@ metadata:
   name: {{ include "cryptpad-helm.fullname" . }}
   labels:
     {{- include "cryptpad-helm.labels" . | nindent 4 }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/cryptpad/values.yaml
+++ b/charts/cryptpad/values.yaml
@@ -232,6 +232,12 @@ nodeSelector: {}
 # -- Values for the Tolerations
 tolerations: []
 
+# -- Ability to annotate the Deployment/Statefullset with annotations like a configmap reloader
+# deployment:
+#   annotations:
+#     reloader.stakater.com/auto: "true"
+deployment: {}
+
 # -- Values for the Affinity
 affinity: {}
 


### PR DESCRIPTION
Adds the ability to annotate the Cryptpad Deployment or StatefulSet with custom annotations via deployment.annotations in the Helm values.